### PR TITLE
'auto' support in fetch and fetchFormat

### DIFF
--- a/src/cloudinary.spec.ts
+++ b/src/cloudinary.spec.ts
@@ -84,6 +84,16 @@ describe('cloudinary configuration', () => {
     )
   })
 
+  it('fetchFormat auto is supported in defaults', () => {
+    const cl = cloudinary({
+      cloudName: 'demo',
+      imageTransformDefaults: { width: 200, crop: 'fill', quality: 'auto', fetchFormat: 'auto' },
+    })
+    expect(cl('something')).toBe(
+      'https://res.cloudinary.com/demo/image/upload/w_200,c_fill,q_auto,f_auto/something',
+    )
+  })
+
   it('merges a single transform with the defaults, and unsets a default when undefined is passed', () => {
     const cl = cloudinary({
       cloudName: 'demo',

--- a/src/transforms/imageTransformTypes.ts
+++ b/src/transforms/imageTransformTypes.ts
@@ -160,8 +160,8 @@ export interface ImageTransform {
   density?: number | string
   dpr?: number | string
   effect?: string
-  fetchFormat?: ImageFileExtension
-  format?: ImageFileExtension
+  fetchFormat?: ImageFileExtension | 'auto'
+  format?: ImageFileExtension | 'auto'
   flags?: ImageFlags | string
   gravity?: Gravity
   height?: number | string


### PR DESCRIPTION
In version 1.x 'auto' was supported as fetch format, this PR add it also to version 2.x