### PR TITLE
Updated validation to allow initial values

### DIFF
--- a/src/transforms/__snapshots__/imageTransforms.spec.ts.snap
+++ b/src/transforms/__snapshots__/imageTransforms.spec.ts.snap
@@ -74,7 +74,7 @@ exports[`Image Transform Parameters gravity throws when invalid 1`] = `"Cloudina
 
 exports[`Image Transform Parameters gravity throws when invalid 2`] = `"Cloudinary Image :: gravity should be one of ['north_west', 'north', 'north_east', 'west', 'center', 'east', 'south_west', 'south', 'south_east', 'xy_center', 'face', 'face:center', 'face:auto', 'faces', 'faces:center', 'faces:auto', 'body', 'body:face', 'ocr_text', 'adv_face', 'adv_faces', 'adv_eyes', 'custom', 'custom:face', 'custom:faces', 'custom:adv_face', 'custom:adv_faces'], 'auto', or a string starting with 'auto:', received: 'auto-bad' - see http://cloudinary.com/documentation/transformation_reference"`;
 
-exports[`Image Transform Parameters height throws when invalid 1`] = `"Cloudinary Image :: height should be a number, received: 'bad' - see http://cloudinary.com/documentation/transformation_reference"`;
+exports[`Image Transform Parameters height throws when invalid 1`] = `"Cloudinary Image :: height should be a number or 'ih', received: 'bad' - see http://cloudinary.com/documentation/transformation_reference"`;
 
 exports[`Image Transform Parameters opacity throws when invalid 1`] = `"Cloudinary Image :: opacity should be a number between 0 and 100, received: -1 - see http://cloudinary.com/documentation/transformation_reference"`;
 

--- a/src/transforms/imageTransforms.spec.ts
+++ b/src/transforms/imageTransforms.spec.ts
@@ -14,6 +14,9 @@ describe('Image Transform Parameters', () => {
     it('accepts a string starting with `auto:`', () => {
       expect(compileImageParameter('width', 'auto:50')).toBe('w_auto:50')
     })
+    it('accepts `iw`', () => {
+      expect(compileImageParameter('width', 'iw')).toBe('w_iw')
+    })
     it('throws when invalid', () => {
       expect(() => compileImageParameter('width', 'bad:auto')).toThrowErrorMatchingSnapshot()
       expect(() => compileImageParameter('width', 'auto-bad')).toThrowErrorMatchingSnapshot()
@@ -26,6 +29,9 @@ describe('Image Transform Parameters', () => {
     })
     it('accepts a numeric string', () => {
       expect(compileImageParameter('height', '300')).toBe('h_300')
+    })
+    it('accepts `ih`', () => {
+      expect(compileImageParameter('height', 'ih')).toBe('h_ih')
     })
     it('throws when invalid', () => {
       expect(() => compileImageParameter('height', 'bad')).toThrowErrorMatchingSnapshot()

--- a/src/transforms/imageTransforms.ts
+++ b/src/transforms/imageTransforms.ts
@@ -149,13 +149,18 @@ type Validators = { [Key in keyof ImgOpt]: (value: ImgOpt[Key]) => void } & {
 const validate: Validators = {
   width: (value: ImgOpt['width']) =>
     invariant(
-      isNumber(value) || (typeof value === 'string' && value.match(/^auto(?:$|(?::.+))/)),
+      isNumber(value) || (typeof value === 'string' && value.match(/^iw$|^auto(?:$|(?::.+))/)),
       'width',
       value,
       `should be a number, 'auto', or a string starting with 'auto:'`,
     ),
   height: (value: ImgOpt['height']) =>
-    invariant(isNumber(value), 'height', value, 'should be a number'),
+    invariant(
+      isNumber(value) || (typeof value === 'string' && value === 'ih'),
+      'height',
+      value,
+      `should be a number or 'ih'`,
+    ),
   crop: (value: ImgOpt['crop']) =>
     invariant(value && includes(value, cropOptions), 'crop', value, shouldBeOneOf(cropOptions)),
   aspectRatio: (value: ImgOpt['aspectRatio']) =>


### PR DESCRIPTION
Adds initial values to the width and height properties (`iw` for width and `ih` for height). Reference: https://cloudinary.com/documentation/transformation_reference#w_width